### PR TITLE
feat: support for `outFile` and `sourceMap` node-sass config options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,31 +1,46 @@
+/*!
+ * node-sass-extra: src/index.js
+ */
+
 const path = require('path');
 const fs = require('fs-extra');
 const glob = require('glob');
 const sass = require('node-sass');
 
-// utility for determining whether a given path is a file (with a supported extension) or not
+/**
+ * Utility for determining whether a given path is a css/sass/scss file or not.
+ *
+ * @param {String} filePath
+ * @api private
+ */
+
 function isFile(filePath) {
     return /\.(s[ca]|c)ss$/.test(filePath);
 }
 
-// utility for flattening arrays; is not recursive, so only flattens down to a single level as
-// that's all that's required
+/**
+ * Utility for flattening arrays; is not recursive, so only flattens down to
+ * a single level as that's all that's required.
+ *
+ * @param {Array} arr
+ * @api private
+ */
+
 function flattenArray(arr) {
     return arr.reduce((flattened, items) => {
         return flattened.concat(items);
     }, []);
 }
 
-// utility for concatenating CSS output from a `node-sass` object
-function concatCompiled(compiled) {
-    return compiled.reduce(
-        (content, { css }) => (content += css.toString()),
-        ''
-    );
-}
+/**
+ * Takes a single source or array of sources and returns a list of files to
+ * be compiled; sources can be file paths or globs.
+ *
+ * @param {String|Array} sources
+ * @return {Array}
+ * @api private
+ */
 
-// takes a single source or array of sources and returns a list of files to be compiled; sources
-// can be file paths or globs
 async function getSourceFiles(sources) {
     const sourcePaths = [].concat(sources);
     const sourceFiles = await Promise.all(
@@ -33,8 +48,8 @@ async function getSourceFiles(sources) {
             sourcePath =>
                 new Promise((resolve, reject) => {
                     glob(sourcePath, (err, sourceFiles) => {
+                        /* istanbul ignore next */
                         if (err) {
-                            /* istanbul ignore next */
                             reject(err);
                         }
 
@@ -49,190 +64,320 @@ async function getSourceFiles(sources) {
     return flattenArray(sourceFiles);
 }
 
-// compiles a given source (file or string) to CSS via node-sass; returns a promise
-async function compile(source, options) {
-    const sourceObj = isFile(source)
-        ? { file: path.resolve(__dirname, source) }
-        : { data: source };
+/**
+ * Compiles via node-sass; returns a promise.
+ *
+ * @param {Object} options
+ * @api private
+ */
 
+async function compile(options) {
     return new Promise((resolve, reject) => {
-        sass.render(
-            {
-                ...sourceObj,
-                ...options,
-            },
-            (err, result) => {
-                if (err) {
-                    /* istanbul ignore next */
-                    reject(err);
-                }
-
-                resolve(result);
+        sass.render(options, (err, result) => {
+            /* istanbul ignore next */
+            if (err) {
+                reject(err);
             }
-        );
+
+            resolve(result);
+        });
     });
 }
 
-// writes compiled CSS to disk at the given destination; returns a promise
-async function writeFile(css, filePath) {
+/**
+ * Writes content to disk at the given destination; returns a promise.
+ *
+ * @param {Object} options
+ * @api private
+ */
+
+async function writeFile(content, filePath) {
     try {
         await fs.ensureDir(path.dirname(filePath));
-        return fs.writeFile(filePath.replace(/\.s(c|a)ss$/, '.css'), css);
+        return fs.writeFile(filePath, content);
     } catch (err) {
         /* istanbul ignore next */
         Promise.reject(err);
     }
 }
 
-// async rendering of source files; maps to nodeSass.render
-async function render(userOptions = {}) {
-    try {
-        // don't mutate the original `options` object
-        const options = { ...userOptions };
-        const { data, file, output } = options;
+/**
+ * Takes one or more sources and config options to determine the essential aspects of a
+ * compilation task; Returns node-sass config object(s) for each source/task.
+ *
+ * For example ...
+ *
+ * getCompilerTasks('src/file.scss', {
+ *     outFile: 'dest'
+ *     sourceMap: true
+ * });
+ *
+ * would produce ...
+ *
+ * {
+ *     file: '//path/to/src/file.scss',
+ *     outFile: '//path/to/dest/file.css',
+ *     sourceMap: '//path/to/dest/file.css.map'
+ * }
+ *
+ * @param {String|Array} sources
+ * @param {Object} config
+ * @api private
+ */
 
-        if (!file && !data) {
-            throw new Error('Either a "data" or "file" option is required.');
-        }
+function getCompilerTasks(sources, config) {
+    const { outFile, sourceMap } = config;
+    let options = {};
 
-        // clean up the options obj to pass to node-sass
-        delete options.data;
-        delete options.file;
-        delete options.output;
+    if (Array.isArray(sources)) {
+        return sources.map(source => getCompilerTasks(source, config));
+    }
 
-        let sources;
-        if (file) {
-            sources = await getSourceFiles(file);
-        } else {
-            sources = data;
-        }
+    // single file source ...
+    if (isFile(sources)) {
+        options.file = path.resolve(__dirname, sources);
 
-        const isSourceArray = Array.isArray(sources);
-        let compiled = isSourceArray
-            ? await Promise.all(sources.map(source => compile(source, options)))
-            : await compile(sources, options);
-
-        // write files to disk?
-        if (output) {
-            // arrayify results for easier handling
-            compiled = [].concat(compiled);
-
-            // single file output; combine the contents of each compiled source
-            if (isFile(output)) {
-                await writeFile(concatCompiled(compiled), path.resolve(output));
+        // determine output file ...
+        if (outFile) {
+            // single file output
+            if (isFile(outFile)) {
+                options.outFile = outFile;
 
                 // dynamic output; run the given iterator function on each source
-            } else if (typeof output === 'function') {
-                const filesToWrite = {};
+            } else if (typeof outFile === 'function') {
+                const output = outFile(sources);
 
-                // group compilation objects by output path so anything writing to the same place
-                // will be concatenated
-                compiled.forEach(result => {
-                    const {
-                        stats: { entry, includedFiles },
-                    } = result;
-                    const outputPath = output(entry, includedFiles);
+                if (!isFile(output)) {
+                    throw new Error(
+                        '"output" and "outFile" function must return a valid file path'
+                    );
+                }
 
-                    if (!isFile(outputPath)) {
-                        throw new Error(
-                            '`output` function must return a valid file path.'
-                        );
-                    }
+                options.outFile = output;
 
-                    if (!filesToWrite[outputPath]) {
-                        filesToWrite[outputPath] = [];
-                    }
-
-                    filesToWrite[outputPath].push(result);
-                });
-
-                await Promise.all(
-                    Object.keys(filesToWrite).map(outputPath => {
-                        const resultsToConcat = filesToWrite[outputPath];
-                        return writeFile(
-                            concatCompiled(resultsToConcat),
-                            outputPath
-                        );
-                    })
-                );
-
-                // output is a directory; keep sources separate and write them individuallly to the
-                // specified location
+                // output is a directory; join the output with the source's basename
             } else {
-                const outputDir = path.resolve(output);
-
-                await Promise.all(
-                    compiled.map(({ css, stats }) => {
-                        const filePath = path.join(
-                            outputDir,
-                            path.basename(stats.entry)
-                        );
-
-                        return writeFile(css, filePath);
-                    })
-                );
+                options.outFile = path.join(outFile, path.basename(sources));
             }
         }
 
-        // return the native nodeSass object(s) from compilation
-        return compiled.length === 1 ? compiled[0] : compiled;
-    } catch (err) {
-        console.error(err);
-        throw err;
+        // single data source ...
+    } else {
+        // add data source to options
+        options.data = sources;
+
+        // determine output file ...
+        if (outFile) {
+            if (isFile(outFile)) {
+                options.outFile = outFile;
+            } else {
+                throw new Error(
+                    '"output" and "outFile" must be a valid file path when accompanying "data".'
+                );
+            }
+        }
     }
+
+    // resolve the output file and ensure it has a '.css' extension.
+    if (options.outFile) {
+        options.outFile = path.resolve(
+            options.outFile.replace(/\.(s[ca]|c)ss$/, '.css')
+        );
+    }
+
+    // determine source map ...
+    if (sourceMap) {
+        if (!options.outFile) {
+            throw new Error(
+                'Either "output" or "outFile" option is required with "sourceMap".'
+            );
+        }
+
+        // single file source map
+        if (typeof sourceMap === 'string') {
+            if (/\.css(\.map)?$/.test(sourceMap)) {
+                options.sourceMap = sourceMap;
+            } else {
+                throw new Error('"sourceMap" must be a valid file path');
+            }
+
+            // dynamic source map; run the given iterator function on each output file
+        } else if (typeof sourceMap === 'function') {
+            const map = sourceMap(options.outFile, options.file);
+
+            if (!/\.css(\.map)?$/.test(map)) {
+                throw new Error(
+                    '"sourceMap" function must return a valid file path'
+                );
+            }
+
+            options.sourceMap = map;
+
+            // `sourceMap` === true; use `outFile` for the path
+        } else {
+            options.sourceMap = options.outFile;
+        }
+
+        // resolve source map file and ensure it has a `.map` file extension
+        options.sourceMap = path.resolve(
+            options.sourceMap.replace(/(\.map)?$/, '.map')
+        );
+    }
+
+    return options;
 }
 
+/**
+ * Async rendering of source files; maps to nodeSass.render.
+ *
+ * @param {Object} options
+ * @return {Object|Array}
+ * @api public
+ */
+
+async function render(userOptions = {}) {
+    // don't mutate the original `options` object
+    let { data, file, output, outFile, sourceMap, ...options } = userOptions;
+
+    // default outFile to match output
+    outFile = output || outFile;
+
+    if (!file && !data) {
+        throw new Error('Either a "data" or "file" option is required.');
+    }
+
+    // retrieve the list of sources
+    const sources = file ? await getSourceFiles(file) : data;
+
+    // retrieve the compiler tasks
+    let tasks = [].concat(getCompilerTasks(sources, { outFile, sourceMap }));
+
+    // compile tasks
+    const compiled = await Promise.all(
+        tasks.map(task =>
+            compile({
+                ...options,
+                ...task,
+            })
+        )
+    );
+
+    // write files to disk?
+    if (output) {
+        await Promise.all(
+            compiled.map(({ css, map }, i) => {
+                const task = tasks[i];
+                let toWrite = [writeFile(css, task.outFile)];
+
+                if (map) {
+                    toWrite.push(writeFile(map, task.sourceMap));
+                }
+
+                return Promise.all(toWrite);
+            })
+        );
+    }
+
+    // return the native nodeSass object(s) from compilation
+    return compiled.length === 1 ? compiled[0] : compiled;
+}
+
+/**
+ * Synchronous rendering of source files; maps to nodeSass.renderSync
+ *
+ * @param {Object} options
+ * @return {Object|Array}
+ * @api public
+ */
+
 function renderSync() {
+    /* istanbul ignore next */
     return false;
 }
+
+/**
+ * Expose the API
+ *
+ * @api public
+ */
 
 const nodeSassExtra = {
     render,
     renderSync,
 };
 
+module.exports = nodeSassExtra;
+
+// --------------------------------------------------------------
 // dev - DELETE ME
+// --------------------------------------------------------------
+
 // nodeSassExtra
 //     .render({
 //         // compile multiple files
-//         // file: ['test-files/test.scss', 'test-files/nested/test.scss'],
-//
+//         file: [
+//             'test-files/test-scss-1.scss',
+//             'test-files/nested/test-scss-2.scss',
+//         ],
+
 //         // compile a single file
-//         // file: 'test-files/test.scss',
-//
+//         // file: 'test-files/test-scss-1.scss',
+
 //         // compile multiple globs
-//         file: ['test-files/**/*.scss', 'test-files/**/*.sass'],
-//
+//         // file: ['test-files/**/*.scss', 'test-files/**/*.sass'],
+
 //         // compile a single glob
 //         // file: 'test-files/**/*.scss',
-//
+
 //         // compile a single data source
-//         // data: '$color: red; body { color: $color; }',
-//
+//         // data: '$color: red; .data { color: $color; }',
+
 //         // compile multiple data sources
 //         // data: [
-//         //     '$color: red; body { color: $color; }',
-//         //     '$padding: 10px; body { padding: $padding; }',
+//         //     '$color: red; .data { color: $color; }',
+//         //     '$padding: 10px; .data-2 { padding: $padding; }',
 //         // ],
-//
+
 //         // output to a directory
-//         // output: 'dest',
-//
+//         output: 'dest',
+//         // outFile: 'dest',
+
 //         // dynamic output
-//         output: sourcePath => {
-//             return sourcePath.replace('test-files', 'test-compiled');
-//         },
-//
+//         // output: sourcePath => {
+//         //     return sourcePath.replace('test-files', 'dest');
+//         // },
+//         // outFile: sourcePath => {
+//         //     return sourcePath.replace('test-files', 'test-compiled');
+//         // },
+
 //         // dynamic output w/concatenation
 //         // output: sourcePath => {
 //         //     const replaced = /\.scss$/.test(sourcePath) ? 'from-scss.css' : 'from-sass.css';
 //         //     return 'test-dest/' + replaced;
 //         // },
-//
+//         // outFile: sourcePath => {
+//         //     const replaced = /\.scss$/.test(sourcePath) ? 'from-scss.css' : 'from-sass.css';
+//         //     return 'test-dest/' + replaced;
+//         // },
+
 //         // output to a single file
 //         // output: 'dest/compiled.css',
-//     })
-//     .then(compiled => console.log('Done!', compiled))
-//     .catch(err => console.log('Error:', err));
+//         // outFile: 'dest/compiled.css',
 
-module.exports = nodeSassExtra;
+//         // source map
+//         // sourceMap: true,
+
+//         // single source map
+//         // sourceMap: 'dest/compiled.css.map'
+
+//         // dynamic source map
+//         // sourceMap: outPath => {
+//         //     return outPath.replace('dest', 'test-compiled')
+//         // }
+//     })
+//     .then(compiled => {
+//         console.log('Done!', compiled);
+//     })
+//     .catch(err => {
+//         console.log('Error:', err);
+//     });

--- a/test-files/nested/deeper/test-scss-3.css
+++ b/test-files/nested/deeper/test-scss-3.css
@@ -1,2 +1,2 @@
-body {
+.test-scss-3_scss {
   margin: 0; }

--- a/test-files/nested/deeper/test-scss-3.scss
+++ b/test-files/nested/deeper/test-scss-3.scss
@@ -1,5 +1,5 @@
 $margin: 0;
 
-body {
+.test-scss-3_scss {
     margin: $margin;
 }

--- a/test-files/nested/test-scss-2.css
+++ b/test-files/nested/test-scss-2.css
@@ -1,2 +1,2 @@
-body {
+.test-scss-2_scss {
   padding: 10px; }

--- a/test-files/nested/test-scss-2.scss
+++ b/test-files/nested/test-scss-2.scss
@@ -1,5 +1,5 @@
 $padding: 10px;
 
-body {
+.test-scss-2_scss {
     padding: $padding;
 }

--- a/test-files/test-scss-1.css
+++ b/test-files/test-scss-1.css
@@ -1,2 +1,2 @@
-body {
+.test-scss-1_scss {
   color: red; }

--- a/test-files/test-scss-1.scss
+++ b/test-files/test-scss-1.scss
@@ -1,5 +1,5 @@
 $color: red;
 
-body {
+.test-scss-1_scss {
     color: $color;
 }


### PR DESCRIPTION
* `outFile` supports the same features as `output` but will not write to disk. 
* If a function is passed to `sourceMap`, it will execute on the output path and use the returned path. 
* `sourceMaps` will be written to disk when provided along with `output`.
* Logic used to determine `output` was moved out of `render` and into a stand-alone utility. 
* Contatenation of multiple sources to a single output was removed temporarily due to incompatibility with source maps. I created #19 for us to add this back later.
* Plus minor updates to utility functions and comments.

closes #18