### PR TITLE
feat: jsdoc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,12 @@
 {
-    "extends": "eslint:recommended",
+    "extends": [
+      "eslint:recommended",
+      "plugin:jsdoc/recommended"
+    ],
     "rules": {
+      "jsdoc/require-returns-description": 0,
+      "jsdoc/require-param-description": 0,
+      "jsdoc/require-jsdoc": 0
     },
     "env": {
       "node": true,
@@ -9,5 +15,8 @@
     },
     "parserOptions": {
         "ecmaVersion": 2018
-    }
+    },
+    "plugins": [
+      "jsdoc"
+    ]
 }

--- a/README.hbs
+++ b/README.hbs
@@ -1,0 +1,10 @@
+# node-sass-extra
+
+A drop-in replacement for [node-sass](https://github.com/sass/node-sass) that adds support for globs, promises and more.
+
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+
+
+# API
+
+{{>main~}}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,207 @@
 # node-sass-extra
 
-A light wrapper around [node-sass](https://github.com/sass/node-sass) to provide support for globs, promises and more.
+A drop-in replacement for [node-sass](https://github.com/sass/node-sass) that adds support for globs, promises and more.
 
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+
+
+# API
+
+<a name="module_node-sass-extra"></a>
+
+## node-sass-extra
+The Node API for `node-sass-extra`.
+
+
+* [node-sass-extra](#module_node-sass-extra)
+    * [~render(options)](#module_node-sass-extra..render) ⇒ <code>Promise</code>
+    * [~renderSync(options)](#module_node-sass-extra..renderSync) ⇒ [<code>nodeSassResult</code>](https://github.com/sass/node-sass#result-object) \| [<code>Array.&lt;nodeSassResult&gt;</code>](https://github.com/sass/node-sass#result-object)
+    * [~options](#module_node-sass-extra..options) : <code>object</code>
+    * [~setOutFile](#module_node-sass-extra..setOutFile) ⇒ <code>string</code>
+    * [~setSourceMap](#module_node-sass-extra..setSourceMap) ⇒ <code>string</code>
+
+<a name="module_node-sass-extra..render"></a>
+
+### node-sass-extra~render(options) ⇒ <code>Promise</code>
+Asynchronous rendering; maps to nodeSass.render. Resolves with [nodeSassResult](https://github.com/sass/node-sass#result-object);
+rejects with [nodeSassError](https://github.com/sass/node-sass#error-object). If more than one source is compiled an array of results is returned.
+
+**Kind**: inner method of [<code>node-sass-extra</code>](#module_node-sass-extra)  
+**Access**: public  
+
+| Param | Type |
+| --- | --- |
+| options | [<code>options</code>](#module_node-sass-extra..options) | 
+
+**Example**  
+```js
+const sass = require('node-sass-extra');
+
+sass.render({
+    file: 'src/*.scss',
+    output: 'css'
+    [, ...options]
+})
+    .then(result => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    });
+```
+**Example**  
+```js
+const sass = require('node-sass-extra');
+
+try {
+    const result = await sass.render({
+        file: 'src/*.scss',
+        output: 'css'
+        [, ...options]
+    });
+} catch (err) {
+    // ...
+}
+```
+<a name="module_node-sass-extra..renderSync"></a>
+
+### node-sass-extra~renderSync(options) ⇒ [<code>nodeSassResult</code>](https://github.com/sass/node-sass#result-object) \| [<code>Array.&lt;nodeSassResult&gt;</code>](https://github.com/sass/node-sass#result-object)
+Synchronous rendering; maps to nodeSass.renderSync. If more than one source is compiled
+an array of results is returned.
+
+**Kind**: inner method of [<code>node-sass-extra</code>](#module_node-sass-extra)  
+**Throws**:
+
+- [<code>nodeSassError</code>](https://github.com/sass/node-sass#error-object) 
+
+**Access**: public  
+
+| Param | Type |
+| --- | --- |
+| options | [<code>options</code>](#module_node-sass-extra..options) | 
+
+**Example**  
+```js
+const sass = require('node-sass-extra');
+
+const result = sass.renderSync({
+    file: 'src/*.scss',
+    output: 'css'
+    [, ...options]
+});
+```
+**Example**  
+```js
+const sass = require('node-sass-extra');
+
+try {
+    const result = sass.renderSync({
+        file: 'src/*.scss',
+        output: 'css'
+        [, ...options]
+    });
+} catch(err) {
+    // ...
+};
+```
+<a name="module_node-sass-extra..options"></a>
+
+### node-sass-extra~options : <code>object</code>
+A `node-sass-extra` config object.
+
+**Kind**: inner typedef of [<code>node-sass-extra</code>](#module_node-sass-extra)  
+**Extends**: [<code>nodeSassOptions</code>](https://github.com/sass/node-sass#options)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| data | <code>string</code> \| <code>Array.&lt;string&gt;</code> | String(s) to be compiled. |
+| file | <code>string</code> \| <code>Array.&lt;string&gt;</code> | File(s) to be compiled; can be a file path or a glob pattern. |
+| output | <code>string</code> \| [<code>setOutFile</code>](#module_node-sass-extra..setOutFile) | The output destination; can be a file path, a directory, or a callback that returns a file path or directory. Must be/return a file path when paried with `data`. If provided, files will be written to disk. |
+| outFile | <code>string</code> \| [<code>setOutFile</code>](#module_node-sass-extra..setOutFile) | The output destination; can be a file path, a directory, or a callback that returns a file path or directory. Must be/return a file path when paried with `data`. `output` will override this value if provided. |
+| sourceMap | <code>string</code> \| [<code>setSourceMap</code>](#module_node-sass-extra..setSourceMap) | The source map destination; can be a boolean, a file path, a directory, or a callback that returns a file path or directory. If a boolean or directory, the file will be named after the output file. |
+| ... | <code>\*</code> | [nodeSassOptions](https://github.com/sass/node-sass#options) |
+
+**Example**  
+```js
+// compiles and writes file
+{
+    file: 'src/file.scss',
+    output: 'css/file.css'
+}
+```
+**Example**  
+```js
+// compiles and creates source maps, but does NOT write them
+{
+    file: 'src/*.scss',
+    outFile: 'css',
+    sourceMap: true
+}
+```
+**Example**  
+```js
+// compiles and creates source maps; writes css to `css/` and source maps to `maps/`
+{
+    file: ['src/file1.scss', 'src/file2.scss'],
+    output: 'css',
+    sourceMap: 'maps'
+}
+```
+**Example**  
+```js
+// compiles and creates source map; writes css and source map to `css/file.css.map`
+{
+    data: '$color: red; .foo { background: $color; } ...',
+    output: 'css/file.css',
+    sourceMap: true
+}
+```
+<a name="module_node-sass-extra..setOutFile"></a>
+
+### node-sass-extra~setOutFile ⇒ <code>string</code>
+Callback for dynamically defining the output path via the source
+file; must return a valid file path.
+
+**Kind**: inner typedef of [<code>node-sass-extra</code>](#module_node-sass-extra)  
+**Returns**: <code>string</code> - A file path.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| srcFile | <code>string</code> | The source file path. |
+
+**Example**  
+```js
+render({
+    file: 'src/path/to/file.scss',
+    output: srcFile => {
+        // returns 'css/path/to/file.css';
+        return srcFile.replace(/src\//, 'css/');
+    }
+});
+```
+<a name="module_node-sass-extra..setSourceMap"></a>
+
+### node-sass-extra~setSourceMap ⇒ <code>string</code>
+Callback for dynamically defining the source map's output path via the
+output and/or source files; must return a valid file path.
+
+**Kind**: inner typedef of [<code>node-sass-extra</code>](#module_node-sass-extra)  
+**Returns**: <code>string</code> - A file path.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| outFile | <code>string</code> | The output file path. |
+| srcFile | <code>string</code> | The source file path. |
+
+**Example**  
+```js
+render({
+    file: 'src/path/to/file.scss',
+    outFile: 'css',
+    sourceMap: (outFile, srcFile) => {
+        // returns 'map/file.css.map';
+        return outFile.replace(/css\//, 'map/');
+    }
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-sass-extra",
   "version": "0.1.0",
-  "description": "A light wrapper around node-sass to provide support for globs, promises and more.",
+  "description": "A drop-in replacement for node-sass that adds support for globs, promises and more.",
   "main": "index.js",
   "engines": {
     "node": ">=7.6.0"
@@ -12,7 +12,8 @@
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",
     "commit": "git cz",
-    "release": "standard-version"
+    "release": "standard-version",
+    "docs": "jsdoc2md index.js -t README.hbs > README.md; echo"
   },
   "repository": {
     "type": "git",
@@ -52,8 +53,10 @@
     "commitizen": "^4.0.3",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^6.0.1",
+    "eslint-plugin-jsdoc": "^15.8.3",
     "husky": "^3.0.1",
     "jest": "^24.8.0",
+    "jsdoc-to-markdown": "^5.0.0",
     "lint-staged": "^9.2.0",
     "prettier": "1.18.2",
     "standard-version": "^6.0.1"


### PR DESCRIPTION
I started this task with the intent to just clean up the comments a little. I then discovered the wonders of jsdoc! I don't know if we want to do this, but I think I really like it.

* Updated comments to meet `jsdoc` standards.
* Added `jsdoc` plugin to `eslint` to enforce compliance.
* Automatically generates API for README via `jsdoc-to-markdown`.
* Updated the project description

*Note: I attempted to tie in the creation of the README at the pre-commit hook, but because I believe it is async, the hook doesn't wait and the commit occurs before the new README is generated*

closes #33