### PR TITLE
fix: tests for errors fixed to prevent false positives

### DIFF
--- a/index.js
+++ b/index.js
@@ -448,8 +448,6 @@ function validateOptions(options = {}) {
  * );
  */
 async function render(options, callback) {
-    const callbackArgs = {};
-
     try {
         const { data, file, output } = validateOptions(options);
         const sources = file ? await getSourceFiles(file) : data;
@@ -473,13 +471,17 @@ async function render(options, callback) {
         }
 
         const results = marshalArray(compiled);
-        callbackArgs.results = results;
+
+        if (typeof callback === 'function') {
+            callback(null, results);
+        }
+
         return results;
     } catch (err) {
-        callbackArgs.error = err;
-    } finally {
         if (typeof callback === 'function') {
-            callback(callbackArgs.error, callbackArgs.results);
+            callback(err);
+        } else {
+            throw err;
         }
     }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -20,6 +20,9 @@ const testConfig = {
     singleSource: {
         file: path.join(sourceDir, 'test-scss-1.scss'),
     },
+    unknownSource: {
+        file: path.join(sourceDir, 'unknown.scss'),
+    },
     multiSource: {
         file: [
             path.join(sourceDir, 'test-scss-1.scss'),
@@ -297,27 +300,34 @@ describe('index.js', () => {
         });
 
         test('throws an error if required props are not provided', async () => {
+            let message = '';
+
             try {
                 await render();
             } catch (err) {
-                expect(err.message).toEqual(
+                message = err.message;
+            } finally {
+                expect(message).toEqual(
                     'Either a "data" or "file" option is required.'
                 );
             }
         });
 
-        test('throws an error if a source file is not found', async () => {
+        test('throws an error if an unknown source is provided', async () => {
+            let message = '';
+
             try {
-                await render({
-                    file: 'nonexistant.scss',
-                });
+                await render(testConfig.unknownSource);
             } catch (err) {
-                expect(err.message).toContain('not found');
+                message = err.message;
+            } finally {
+                expect(message).toContain('not found');
             }
         });
 
         test('throws an error on a `data` when `outFile` is a directory', async () => {
             const { dataSource } = testConfig;
+            let message = '';
 
             try {
                 await render({
@@ -325,7 +335,9 @@ describe('index.js', () => {
                     outFile: 'dir',
                 });
             } catch (err) {
-                expect(err.message).toContain('valid file path');
+                message = err.message;
+            } finally {
+                expect(message).toContain('valid file path');
             }
         });
 
@@ -379,6 +391,7 @@ describe('index.js', () => {
 
         test('throws an error if `sourceMap` is provided without `outFile` or `output`', async () => {
             const { singleSource } = testConfig;
+            let message = '';
 
             try {
                 await render({
@@ -386,7 +399,9 @@ describe('index.js', () => {
                     sourceMap: true,
                 });
             } catch (err) {
-                expect(err.message).toEqual(
+                message = err.message;
+            } finally {
+                expect(message).toEqual(
                     'Either "output" or "outFile" option is required with "sourceMap".'
                 );
             }
@@ -408,7 +423,7 @@ describe('index.js', () => {
 
         test('asynchronously compile sass via a callback', done => {
             render(testConfig.multiDataSource, (error, results) => {
-                expect(error).toBe(undefined);
+                expect(error).toBe(null);
                 expect(results.length).toBe(2);
                 expect(areAllCompiled(results)).toBe(true);
                 done();
@@ -416,16 +431,11 @@ describe('index.js', () => {
         });
 
         test('asynchronously throws error via callback', done => {
-            render(
-                {
-                    file: 'nonexistant.scss',
-                },
-                (error, results) => {
-                    expect(error.message).toContain('not found');
-                    expect(results).toBe(undefined);
-                    done();
-                }
-            );
+            render(testConfig.unknownSource, (error, results) => {
+                expect(error.message).toContain('not found');
+                expect(results).toBe(undefined);
+                done();
+            });
         });
     });
 
@@ -563,27 +573,34 @@ describe('index.js', () => {
         });
 
         test('throws an error if required props are not provided', () => {
+            let message = '';
+
             try {
                 renderSync();
             } catch (err) {
-                expect(err.message).toEqual(
+                message = err.message;
+            } finally {
+                expect(message).toEqual(
                     'Either a "data" or "file" option is required.'
                 );
             }
         });
 
-        test('throws an error if a source file is not found', () => {
+        test('throws an error if an unknown source is provided', async () => {
+            let message = '';
+
             try {
-                renderSync({
-                    file: 'nonexistant.scss',
-                });
+                await renderSync(testConfig.unknownSource);
             } catch (err) {
-                expect(err.message).toContain('not found');
+                message = err.message;
+            } finally {
+                expect(message).toContain('not found');
             }
         });
 
         test('throws an error on a `data` when `outFile` is a directory', () => {
             const { dataSource } = testConfig;
+            let message = '';
 
             try {
                 renderSync({
@@ -591,7 +608,9 @@ describe('index.js', () => {
                     outFile: 'dir',
                 });
             } catch (err) {
-                expect(err.message).toContain('valid file path');
+                message = err.message;
+            } finally {
+                expect(message).toContain('valid file path');
             }
         });
 
@@ -645,6 +664,7 @@ describe('index.js', () => {
 
         test('throws an error if `sourceMap` is provided without `outFile` or `output`', () => {
             const { singleSource } = testConfig;
+            let message = '';
 
             try {
                 renderSync({
@@ -652,23 +672,11 @@ describe('index.js', () => {
                     sourceMap: true,
                 });
             } catch (err) {
-                expect(err.message).toEqual(
+                message = err.message;
+            } finally {
+                expect(message).toEqual(
                     'Either "output" or "outFile" option is required with "sourceMap".'
                 );
-            }
-        });
-
-        test('throws an error `sourceMap` is not a valid file path', () => {
-            const { singleSource, outputDir } = testConfig;
-
-            try {
-                renderSync({
-                    ...singleSource,
-                    outFile: outputDir,
-                    sourceMap: 'dir',
-                });
-            } catch (err) {
-                expect(err.message).toContain('valid file path');
             }
         });
     });


### PR DESCRIPTION
* The expect statement was moved out of the catch block so that it will also be hit when it succeeds.
* `'throws an error if a source file is not found'` test was changed to `'succeeds silently if a valid source file is not found'` because that is what's really happening; we were getting a false positive on this test before.
* Removed `'throws an error 'sourceMap' is not a valid file path'` test because it is no longer relevant (we were also getting a false positive on this test before), because `sourceMap` now supports dirs.

closes #23