### PR TITLE
fix: invalid options type throws error

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,7 +294,7 @@ function getOutFile(source, outFile) {
     // throw error if the determined output is not a valid file path
     if (!isFile(outFile)) {
         throw new Error(
-            `"${outFile}" is not a valid file path for "output" or "outFile".`
+            `Invalid output: "${outFile}" is not a valid file path for "output" or "outFile".`
         );
     }
 
@@ -379,16 +379,22 @@ function getTasks(sources, options) {
  * @throws {Error}
  * @private
  */
-function validateOptions(options = {}) {
+function validateOptions(options) {
+    if (typeof options !== 'object') {
+        throw new Error('Invalid: options is not an object');
+    }
+
     const { data, file, output, outFile, sourceMap } = options;
 
     if (!file && !data) {
-        throw new Error('Either a "data" or "file" option is required.');
+        throw new Error(
+            'No input specified: either the "data" or "file" option is required.'
+        );
     }
 
     if (sourceMap && (!output && !outFile)) {
         throw new Error(
-            'Either "output" or "outFile" option is required with "sourceMap".'
+            'No output specified: either the "output" or "outFile" option is required with "sourceMap".'
         );
     }
 

--- a/index.test.js
+++ b/index.test.js
@@ -299,17 +299,27 @@ describe('index.js', () => {
             expect(areAllDynamic).toBe(true);
         });
 
+        test('throws an error if invalid props are provided', async () => {
+            let message = '';
+
+            try {
+                await render('foo');
+            } catch (err) {
+                message = err.message;
+            } finally {
+                expect(message).toContain('Invalid');
+            }
+        });
+
         test('throws an error if required props are not provided', async () => {
             let message = '';
 
             try {
-                await render();
+                await render({});
             } catch (err) {
                 message = err.message;
             } finally {
-                expect(message).toEqual(
-                    'Either a "data" or "file" option is required.'
-                );
+                expect(message).toContain('is required');
             }
         });
 
@@ -337,7 +347,7 @@ describe('index.js', () => {
             } catch (err) {
                 message = err.message;
             } finally {
-                expect(message).toContain('valid file path');
+                expect(message).toContain('Invalid');
             }
         });
 
@@ -401,9 +411,7 @@ describe('index.js', () => {
             } catch (err) {
                 message = err.message;
             } finally {
-                expect(message).toEqual(
-                    'Either "output" or "outFile" option is required with "sourceMap".'
-                );
+                expect(message).toContain('is required');
             }
         });
 
@@ -417,7 +425,7 @@ describe('index.js', () => {
                     sourceMap: 'dir',
                 });
             } catch (err) {
-                expect(err.message).toContain('valid file path');
+                expect(err.message).toContain('Invalid');
             }
         });
 
@@ -572,17 +580,27 @@ describe('index.js', () => {
             expect(areAllDynamic).toBe(true);
         });
 
+        test('throws an error if invalid props are provided', async () => {
+            let message = '';
+
+            try {
+                renderSync('foo');
+            } catch (err) {
+                message = err.message;
+            } finally {
+                expect(message).toContain('Invalid');
+            }
+        });
+
         test('throws an error if required props are not provided', () => {
             let message = '';
 
             try {
-                renderSync();
+                renderSync({});
             } catch (err) {
                 message = err.message;
             } finally {
-                expect(message).toEqual(
-                    'Either a "data" or "file" option is required.'
-                );
+                expect(message).toContain('is required');
             }
         });
 
@@ -610,7 +628,7 @@ describe('index.js', () => {
             } catch (err) {
                 message = err.message;
             } finally {
-                expect(message).toContain('valid file path');
+                expect(message).toContain('Invalid');
             }
         });
 
@@ -674,9 +692,7 @@ describe('index.js', () => {
             } catch (err) {
                 message = err.message;
             } finally {
-                expect(message).toEqual(
-                    'Either "output" or "outFile" option is required with "sourceMap".'
-                );
+                expect(message).toContain('is required');
             }
         });
     });


### PR DESCRIPTION
Error is thrown if a non-object is passed into options. Error messages were updated to emulate the
verbiage of node-sass' error messaging.

closes #38