### PR TITLE
feat: concatenate sources that have the same output

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,14 +208,13 @@ output and/or source file.
 | Param | Type | Description |
 | --- | --- | --- |
 | outFile | <code>string</code> | The output file path. |
-| srcFile | <code>string</code> | The source file path. |
 
 **Example**  
 ```js
 render({
     file: 'src/path/to/file.scss',
     outFile: 'css',
-    sourceMap: (outFile, srcFile) => {
+    sourceMap: (outFile) => {
         // returns 'map/file.css.map';
         return outFile.replace(/css\//, 'map/');
     }

--- a/index.test.js
+++ b/index.test.js
@@ -445,6 +445,31 @@ describe('index.js', () => {
                 done();
             });
         });
+
+        test('concat data sources with single output', async () => {
+            const results = await render({
+                ...testConfig.multiDataSource,
+                ...testConfig.singleOutFile,
+            });
+
+            const css = results.css.toString();
+
+            expect(css.indexOf('color: red')).toBeGreaterThan(-1);
+            expect(css.indexOf('padding: 10px;')).toBeGreaterThan(-1);
+        });
+
+        test('concat file sources with single output', async () => {
+            const results = await render({
+                ...testConfig.multiSource,
+                ...testConfig.singleOutFile,
+            });
+
+            const css = results.css.toString();
+
+            expect(css.indexOf('test-scss-1')).toBeGreaterThan(-1);
+            expect(css.indexOf('test-scss-2')).toBeGreaterThan(-1);
+            expect(css.indexOf('test-scss-3')).toBeGreaterThan(-1);
+        });
     });
 
     //
@@ -694,6 +719,31 @@ describe('index.js', () => {
             } finally {
                 expect(message).toContain('is required');
             }
+        });
+
+        test('concat data sources with single output', () => {
+            const results = renderSync({
+                ...testConfig.multiDataSource,
+                ...testConfig.singleOutFile,
+            });
+
+            const css = results.css.toString();
+
+            expect(css.indexOf('color: red')).toBeGreaterThan(-1);
+            expect(css.indexOf('padding: 10px;')).toBeGreaterThan(-1);
+        });
+
+        test('concat file sources with single output', () => {
+            const results = renderSync({
+                ...testConfig.multiSource,
+                ...testConfig.singleOutFile,
+            });
+
+            const css = results.css.toString();
+
+            expect(css.indexOf('test-scss-1')).toBeGreaterThan(-1);
+            expect(css.indexOf('test-scss-2')).toBeGreaterThan(-1);
+            expect(css.indexOf('test-scss-3')).toBeGreaterThan(-1);
         });
     });
 });


### PR DESCRIPTION
Compiler tasks that have the same output file are grouped and their sources concatenated; data
sources are concatenated directly, file sources are concatenated as sass import statements. Also,
removed source from setSourceMap callback to keep in sync with outFile and because source can also be a data string.

closes #19